### PR TITLE
Look for ForthOS in extended partitions

### DIFF
--- a/kernel/ide.shd
+++ b/kernel/ide.shd
@@ -183,6 +183,23 @@ Words to access the needed fields in a partition; array of partitions
   overall size of one partition entry
 : partok? Tell if magic # is OK for partition sector
 
+: parse-ext-part From an EBR get:
+ partition type
+ starting sector offset from this EBR
+ starting sector offset of next EBR from start of extended partition
+
+
+
+
+
+
+
+
+
+
+
+
+
 : init-ideoff Read fdisk label, find our partition and set ideoff to
  make this the start of our blocks.  If can't find partition, clear
  ideoff to make "block" see the whole raw disk.
@@ -190,6 +207,14 @@ Words to access the needed fields in a partition; array of partitions
 
 
 
+ Not a primary partition, let's try again with extended ones
+
+ We will need the start of both the extended partition and the current EBR
+ Extract data from current EBR
+
+
+ Stop when there are no more logical partitions
+ Calc next EBR absolute sector number
 
 
 

--- a/kernel/ide.txt
+++ b/kernel/ide.txt
@@ -136,7 +136,7 @@ $20 constant IDECMD_READ   $30 constant IDECMD_WRITE
 
    drop ;
 
-
+: iderdsec ( n -- a-sec-n ) align here dup rot IDECMD_READ ideio ;
 
 
 
@@ -183,15 +183,40 @@ $20 constant IDECMD_READ   $30 constant IDECMD_WRITE
 16 constant part.size
 : partok? ( a -- ? )   510 + @   $FFFF and $AA55 = ;
 
+: parse-ext-part ( a-ebr -- ptype offset next-offset )
+   dup partok? if
+      sec>parts   dup part>type c@   swap dup part>start @
+      swap part.size +   dup part>type c@   0= if   drop 0
+         else   part>start @   then
+   else   drop 0 0 0
+   then ;
+
+
+
+
+
+
+
+
+\                                                                    vandys
+
 : init-ideoff ( -- )   ideoff off
-   align here   dup 0 IDECMD_READ ideio ( a-sec0 )
+   0 iderdsec ( a-sec0 )
    dup partok? 0= if   drop exit   then
    sec>parts   NFDISK 0 do   dup part>type c@ PT_FORTHOS = if
          part>start @   ideoff !   unloop exit   then
+      part.size +   loop drop
+
+   0 iderdsec
+   sec>parts   NFDISK 0 do   dup part>type c@ 5 = if
+         dup part>start @ dup   begin
+            dup iderdsec parse-ext-part
+            rot PT_FORTHOS = if
+               drop + ideoff !   2drop unloop exit   then
+            dup   while
+            nip nip over +   repeat
+         2drop   then
       part.size +   loop drop ;
-
-
-
 
 
 


### PR DESCRIPTION
If a type 158 partition is not found among the primary partitions, also walk the extended partitions list if it exists.

Works for me, but there are a few things to watch out for if you are going to merge this (feel free to reject it without a word otherwise):
- Correctness. These are my first lines of FORTH, and it took a day until the aha! moment when I finally understood why I could just exit a begin - while - repeat without unloop or any other return stack game.
- An ill-formed extended partitions list can lead to an infinite loop. You may want to change the begin repeat for an artificially limited do loop.
- There are a few more types for extended partitions. 5 is just what I have on my PC. 15 (decimal) might also be common and work in the same way.
- kernel/ide is a block bigger.